### PR TITLE
Update EMRLD.yml

### DIFF
--- a/docassemble/emrld/data/questions/EMRLD.yml
+++ b/docassemble/emrld/data/questions/EMRLD.yml
@@ -239,9 +239,6 @@ review:
   - Change: rental_city
     button: |
       City:   ${ rental_city }
-  - Change: rental_province
-    button: |
-      Province:   ${ rental_province }
   - Change: rental_zip
     button: |
       Postal Code:   ${ rental_zip }


### PR DESCRIPTION
removed rental_province. That is hardcoded on the PDF as AB. This form cannot be used for any rental outside of AB.